### PR TITLE
fix: Prevent JSON parsing errors in AJAX responses

### DIFF
--- a/src/Helper/WhichPoliceForceHelper.php
+++ b/src/Helper/WhichPoliceForceHelper.php
@@ -36,6 +36,7 @@ class WhichPoliceForceHelper
         // Check CSRF token
         if (!Session::checkToken('get')) {
             echo new JsonResponse(null, 'Invalid Token', true);
+            Factory::getApplication()->close();
             return;
         }
         
@@ -47,6 +48,7 @@ class WhichPoliceForceHelper
         
         if (empty($postcode)) {
             echo new JsonResponse(null, 'Please provide a postcode', true);
+            Factory::getApplication()->close();
             return;
         }
         
@@ -60,6 +62,7 @@ class WhichPoliceForceHelper
             
             if ($data === false) {
                 echo new JsonResponse(null, 'Unable to find police force for this postcode', true);
+                Factory::getApplication()->close();
                 return;
             }
             
@@ -78,9 +81,11 @@ class WhichPoliceForceHelper
             ];
             
             echo new JsonResponse($response);
+            Factory::getApplication()->close();
             
         } catch (\Exception $e) {
             echo new JsonResponse(null, 'An error occurred while processing your request', true);
+            Factory::getApplication()->close();
         }
     }
     


### PR DESCRIPTION
## Summary
- Fixed JSON parsing errors occurring in AJAX responses
- Ensures clean JSON output without trailing HTML

## Issue
The module was experiencing "Unexpected non-whitespace character after JSON" errors when making AJAX requests. This was caused by Joomla adding additional HTML output after the JSON response.

## Solution
Added `Factory::getApplication()->close()` after each `JsonResponse` output to properly terminate the application and prevent any additional content from being appended.

## Changes
- Updated all 5 JSON response points in `WhichPoliceForceHelper::getAjax()`
- Each response now properly closes the application after output

## Test Plan
- [ ] Install updated module
- [ ] Enter a valid UK postcode (e.g., DA12 1EF)
- [ ] Verify response displays without errors
- [ ] Check browser console - no JSON parsing errors
- [ ] Test invalid postcode - verify error message displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)