### PR TITLE
Improve module styling and add location information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to the Which Police Force module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2025-06-20
+
+### Added
+- Location details from postcodes.io API including district, ward, parish, constituency, region and country
+- Display of comprehensive area information in the results
+- Template-agnostic styling approach for better theme compatibility
+
+### Changed
+- Completely refactored CSS to remove opinionated styling
+- Removed all color definitions, backgrounds, borders and shadows
+- Removed dark mode styles (now handled by template)
+- Simplified responsive and print styles
+- Updated JavaScript to dynamically display available area fields
+
+### Improved
+- Module now blends naturally with any Joomla template's styling
+- Enhanced user information with detailed geographic context
+
+## [1.0.1] - 2025-06-19
+
+### Fixed
+- JSON response output issues in AJAX handler
+- Prevented double JSON encoding in API responses
+
+## [1.0.0] - 2025-06-18
+
+### Added
+- Initial release
+- UK postcode lookup functionality
+- Integration with UK Police API
+- AJAX-based interface
+- Caching system for API responses
+- Responsive design
+- Multilingual support structure

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cd ~/which-police-force
 ./scripts/setup-dev.sh
 
 # Access test site
-http://forge.armadillo-firefighter.ts.net/whichpolice-test/
+http://example.com/whichpolice-test/
 ```
 
 ### VS Code Remote Development

--- a/README.md
+++ b/README.md
@@ -7,14 +7,16 @@ A Joomla 5 module that allows users to find which UK police force covers their a
 ### Features
 - 🔍 **Postcode Lookup**: Enter any UK postcode to find the responsible police force
 - 🌐 **Live API Integration**: Uses UK Police API and Postcodes.io for accurate data
+- 📍 **Location Details**: Displays area information including district, ward, parish, constituency, region and country
 - ⚡ **AJAX Interface**: Smooth user experience without page reloads
 - 💾 **Intelligent Caching**: Reduces API calls and improves performance
 - 📱 **Responsive Design**: Works perfectly on all devices
+- 🎨 **Template-Agnostic Styling**: Minimal CSS that adapts to any Joomla template
 - 🌍 **Multilingual Ready**: Full language string support for translations
 
 ## Installation
 
-1. Download the module package: `mod_whichpoliceforce_v1.0.0.zip`
+1. Download the module package: `mod_whichpoliceforce_v1.1.0.zip`
 2. In Joomla Administrator, go to **System → Install → Extensions**
 3. Upload and install the package
 4. Go to **Content → Site Modules**
@@ -52,8 +54,9 @@ For the best development experience, use VS Code with Remote-SSH:
 - **Cache Time**: How long to cache API results (default: 15 minutes)
 
 ### Styling
-- Module uses Bootstrap classes
-- Custom CSS in `assets/css/style.css`
+- Module uses minimal, template-agnostic CSS
+- Relies on template's Bootstrap/framework classes
+- Custom CSS in `media/css/style.css` provides only structural styles
 - Responsive design included
 
 ## License

--- a/media/css/style.css
+++ b/media/css/style.css
@@ -72,6 +72,14 @@
     margin: 0;
 }
 
+.police-force-links a[href^="tel:"] {
+    cursor: pointer;
+}
+
+.police-force-links a[href^="tel:"]:hover {
+    text-decoration: underline !important;
+}
+
 /* Loading State */
 .whichpoliceforce-loading {
     display: inline-flex;

--- a/media/css/style.css
+++ b/media/css/style.css
@@ -4,19 +4,14 @@
  * @license     GNU General Public License version 2 or later
  */
 
+/* Minimal structural styles - let template handle colors and styling */
 .mod-whichpoliceforce {
-    padding: 1.5rem;
-    background: #f8f9fa;
-    border-radius: 0.5rem;
+    padding: 1rem;
     margin-bottom: 1.5rem;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 .mod-whichpoliceforce h3 {
-    color: #1d3557;
-    margin-bottom: 1.25rem;
-    font-size: 1.5rem;
-    font-weight: 600;
+    margin-bottom: 1rem;
 }
 
 /* Form Styles */
@@ -40,59 +35,30 @@
 .whichpoliceforce-postcode {
     width: 100%;
     text-transform: uppercase;
-    font-family: 'Courier New', monospace;
-    font-size: 1.1rem;
-    letter-spacing: 0.1em;
     padding: 0.5rem 0.75rem;
-    border: 2px solid #dee2e6;
-    border-radius: 0.25rem;
-    transition: border-color 0.15s ease-in-out;
-}
-
-.whichpoliceforce-postcode:focus {
-    border-color: #0066cc;
-    outline: none;
-    box-shadow: 0 0 0 0.2rem rgba(0,102,204,0.25);
 }
 
 .whichpoliceforce-form button {
     white-space: nowrap;
-    font-weight: 500;
     padding: 0.5rem 1.5rem;
-    background-color: #0066cc;
-    border-color: #0066cc;
-    transition: all 0.15s ease-in-out;
-}
-
-.whichpoliceforce-form button:hover {
-    background-color: #0052a3;
-    border-color: #0052a3;
-    transform: translateY(-1px);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 /* Result Display */
-.whichpoliceforce-result .alert {
-    margin-bottom: 0;
-    border: none;
-    border-left: 4px solid #0066cc;
-    background-color: #e8f4fd;
-    color: #1d3557;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+.whichpoliceforce-result {
+    margin-top: 1rem;
 }
 
 .police-force-name {
-    color: #0066cc;
     margin: 0 0 0.5rem 0;
-    font-size: 1.35rem;
-    font-weight: 600;
+    font-size: 1.25rem;
 }
 
 .police-force-neighbourhood {
-    color: #6c757d;
+    margin-bottom: 0.5rem;
+}
+
+.police-force-area {
     margin-bottom: 1rem;
-    font-size: 1rem;
-    line-height: 1.5;
 }
 
 .police-force-links {
@@ -104,14 +70,6 @@
 
 .police-force-links .btn {
     margin: 0;
-    font-weight: 500;
-}
-
-.police-force-links .text-muted {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.95rem;
 }
 
 /* Loading State */
@@ -120,44 +78,15 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.5rem 0;
-    color: #0066cc;
-}
-
-.whichpoliceforce-loading .spinner-border {
-    width: 1.25rem;
-    height: 1.25rem;
-    border-width: 2px;
 }
 
 /* Error State */
-.whichpoliceforce-error .alert {
-    margin-bottom: 0;
-    border: none;
-    border-left: 4px solid #dc3545;
-    background-color: #f8d7da;
-    color: #721c24;
+.whichpoliceforce-error {
+    margin-top: 1rem;
 }
 
 .error-message {
     margin: 0;
-    font-weight: 500;
-}
-
-/* Animations */
-.whichpoliceforce-result,
-.whichpoliceforce-error {
-    animation: fadeIn 0.3s ease-in-out;
-}
-
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
 }
 
 /* Responsive Design */
@@ -176,9 +105,6 @@
         min-width: 100%;
     }
     
-    .whichpoliceforce-postcode {
-        font-size: 1rem;
-    }
     
     .whichpoliceforce-form button {
         width: 100%;
@@ -196,63 +122,15 @@
     }
 }
 
-/* Dark Mode Support */
-@media (prefers-color-scheme: dark) {
-    .mod-whichpoliceforce {
-        background: #2d3748;
-        color: #e2e8f0;
-    }
-    
-    .mod-whichpoliceforce h3 {
-        color: #e2e8f0;
-    }
-    
-    .whichpoliceforce-postcode {
-        background-color: #1a202c;
-        border-color: #4a5568;
-        color: #e2e8f0;
-    }
-    
-    .whichpoliceforce-postcode:focus {
-        border-color: #4299e1;
-        box-shadow: 0 0 0 0.2rem rgba(66,153,225,0.25);
-    }
-    
-    .whichpoliceforce-result .alert {
-        background-color: #2c5282;
-        border-color: #4299e1;
-        color: #e2e8f0;
-    }
-    
-    .police-force-name {
-        color: #90cdf4;
-    }
-    
-    .whichpoliceforce-error .alert {
-        background-color: #742a2a;
-        border-color: #fc8181;
-        color: #fed7d7;
-    }
-}
-
 /* Print Styles */
 @media print {
-    .mod-whichpoliceforce {
-        box-shadow: none;
-        border: 1px solid #dee2e6;
-    }
-    
     .whichpoliceforce-form,
     .whichpoliceforce-loading {
         display: none !important;
     }
     
-    .whichpoliceforce-error {
-        page-break-inside: avoid;
-    }
-    
+    .whichpoliceforce-error,
     .whichpoliceforce-result {
-        display: block !important;
         page-break-inside: avoid;
     }
 }

--- a/media/js/script.js
+++ b/media/js/script.js
@@ -156,8 +156,9 @@
                 if (data.force_telephone) {
                     const telLink = document.createElement('a');
                     telLink.href = 'tel:' + data.force_telephone.replace(/\s/g, '');
-                    telLink.className = 'text-muted text-decoration-none';
+                    telLink.className = 'text-decoration-none';
                     telLink.innerHTML = '<i class="fas fa-phone"></i> ' + data.force_telephone;
+                    telLink.title = 'Click to call';
                     linksEl.appendChild(telLink);
                 }
             }

--- a/media/js/script.js
+++ b/media/js/script.js
@@ -91,6 +91,7 @@
         function showResult(data) {
             const nameEl = resultDiv.querySelector('.police-force-name');
             const neighbourhoodEl = resultDiv.querySelector('.police-force-neighbourhood');
+            const areaEl = resultDiv.querySelector('.police-force-area');
             const linksEl = resultDiv.querySelector('.police-force-links');
             
             if (nameEl) {
@@ -103,6 +104,38 @@
                     neighbourhoodText = 'Postcode ' + data.postcode + ' - ' + neighbourhoodText;
                 }
                 neighbourhoodEl.textContent = neighbourhoodText;
+            }
+            
+            // Display area information if available
+            if (areaEl && data.area) {
+                areaEl.innerHTML = '';
+                const areaItems = [];
+                
+                if (data.area.district) {
+                    areaItems.push('District: ' + data.area.district);
+                }
+                if (data.area.ward) {
+                    areaItems.push('Ward: ' + data.area.ward);
+                }
+                if (data.area.parish) {
+                    areaItems.push('Parish: ' + data.area.parish);
+                }
+                if (data.area.constituency) {
+                    areaItems.push('Constituency: ' + data.area.constituency);
+                }
+                if (data.area.region) {
+                    areaItems.push('Region: ' + data.area.region);
+                }
+                if (data.area.country) {
+                    areaItems.push('Country: ' + data.area.country);
+                }
+                
+                if (areaItems.length > 0) {
+                    const areaP = document.createElement('p');
+                    areaP.className = 'mb-2';
+                    areaP.innerHTML = areaItems.join(' • ');
+                    areaEl.appendChild(areaP);
+                }
             }
             
             if (linksEl) {

--- a/media/js/script.js
+++ b/media/js/script.js
@@ -101,7 +101,7 @@
             if (neighbourhoodEl) {
                 let neighbourhoodText = 'Neighbourhood: ' + (data.neighbourhood || 'Unknown');
                 if (data.postcode) {
-                    neighbourhoodText = 'Postcode ' + data.postcode + ' - ' + neighbourhoodText;
+                    neighbourhoodText = 'Postcode ' + data.postcode.toUpperCase() + ' - ' + neighbourhoodText;
                 }
                 neighbourhoodEl.textContent = neighbourhoodText;
             }
@@ -154,10 +154,11 @@
                 
                 // Add telephone if available
                 if (data.force_telephone) {
-                    const telEl = document.createElement('span');
-                    telEl.className = 'text-muted';
-                    telEl.innerHTML = '<i class="fas fa-phone"></i> ' + data.force_telephone;
-                    linksEl.appendChild(telEl);
+                    const telLink = document.createElement('a');
+                    telLink.href = 'tel:' + data.force_telephone.replace(/\s/g, '');
+                    telLink.className = 'text-muted text-decoration-none';
+                    telLink.innerHTML = '<i class="fas fa-phone"></i> ' + data.force_telephone;
+                    linksEl.appendChild(telLink);
                 }
             }
             

--- a/media/js/script.js
+++ b/media/js/script.js
@@ -101,7 +101,7 @@
             if (neighbourhoodEl) {
                 let neighbourhoodText = 'Neighbourhood: ' + (data.neighbourhood || 'Unknown');
                 if (data.postcode) {
-                    neighbourhoodText = 'Postcode ' + data.postcode.toUpperCase() + ' - ' + neighbourhoodText;
+                    neighbourhoodText = 'Postcode ' + data.postcode + ' - ' + neighbourhoodText;
                 }
                 neighbourhoodEl.textContent = neighbourhoodText;
             }

--- a/mod_whichpoliceforce.xml
+++ b/mod_whichpoliceforce.xml
@@ -8,7 +8,7 @@
     <license>GNU General Public License version 2 or later; see LICENSE</license>
     <authorEmail>phil@softforge.co.uk</authorEmail>
     <authorUrl>https://softforge.co.uk</authorUrl>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <description>MOD_WHICHPOLICEFORCE_DESC</description>
     
     <files>

--- a/src/Helper/WhichPoliceForceHelper.php
+++ b/src/Helper/WhichPoliceForceHelper.php
@@ -69,6 +69,9 @@ class WhichPoliceForceHelper
             // Get force details
             $forceDetails = self::getForceDetails($data->force);
             
+            // Get postcode details for area information
+            $postcodeDetails = self::getPostcodeData($postcode);
+            
             // Prepare response data
             $response = [
                 'postcode' => $postcode,
@@ -77,7 +80,16 @@ class WhichPoliceForceHelper
                 'force_name' => $forceDetails->name ?? $data->force ?? 'Unknown Police Force',
                 'force_url' => $forceDetails->url ?? null,
                 'force_telephone' => $forceDetails->telephone ?? null,
-                'force_description' => $forceDetails->description ?? null
+                'force_description' => $forceDetails->description ?? null,
+                // Area information from postcode data
+                'area' => [
+                    'district' => $postcodeDetails->admin_district ?? null,
+                    'ward' => $postcodeDetails->admin_ward ?? null,
+                    'parish' => $postcodeDetails->parish ?? null,
+                    'constituency' => $postcodeDetails->parliamentary_constituency ?? null,
+                    'region' => $postcodeDetails->region ?? null,
+                    'country' => $postcodeDetails->country ?? null
+                ]
             ];
             
             echo new JsonResponse($response);

--- a/src/Helper/WhichPoliceForceHelper.php
+++ b/src/Helper/WhichPoliceForceHelper.php
@@ -74,7 +74,7 @@ class WhichPoliceForceHelper
             
             // Prepare response data
             $response = [
-                'postcode' => $postcode,
+                'postcode' => strtoupper($postcode),
                 'force' => $data->force ?? 'Unknown',
                 'neighbourhood' => $data->neighbourhood ?? 'Unknown',
                 'force_name' => $forceDetails->name ?? $data->force ?? 'Unknown Police Force',

--- a/tmpl/default.php
+++ b/tmpl/default.php
@@ -52,6 +52,7 @@ $document->addScript('/whichpolice-test/media/mod_whichpoliceforce/js/script.js'
         <div class="alert alert-info">
             <h4 class="police-force-name"></h4>
             <p class="police-force-neighbourhood"></p>
+            <div class="police-force-area"></div>
             <div class="police-force-links"></div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Remove opinionated styling to make module template-agnostic
- Add area/location information from postcodes.io API
- Display geographic details including district, ward, parish, constituency, region, and country

## Changes Made

### 1. CSS Improvements (style.css)
- Removed all color definitions, backgrounds, and borders
- Removed shadows and specific visual styling  
- Kept only structural CSS for layout and spacing
- Removed dark mode styles (let template handle theming)
- Made the module blend naturally with any Joomla template

### 2. API Enhancement
- Added area information retrieval from postcodes.io API
- Enhanced helper to include location data in response
- Updated JavaScript to display area fields dynamically
- Added new HTML structure for area display

## Test Plan
- [x] Test with valid UK postcode - area information displays correctly
- [x] Test with different Joomla templates - styling adapts appropriately
- [x] Test error cases (invalid postcode) - errors display cleanly
- [x] Verify existing functionality still works (police force lookup)
- [x] Check responsive display on mobile devices

## Screenshots
The module now displays additional location context and uses minimal styling that adapts to the template.

🤖 Generated with [Claude Code](https://claude.ai/code)